### PR TITLE
feat: link stop variants

### DIFF
--- a/front/src/views/arret.vue
+++ b/front/src/views/arret.vue
@@ -10,12 +10,32 @@ defineOptions({ name: 'ArretPage' })
 const route = useRoute()
 
 const lignes = ref({})
+const variantesMap = ref({})
 
 onMounted(async () => {
   try {
     const response = await api.get(`/getTempsLieu/${route.params.nom}`)
     if (response.data) {
       lignes.value = response.data
+
+      // Récupération des variantes desservant l'arrêt
+      const idArret = lignes.value.listeTemps?.[0]?.idArret
+      if (idArret) {
+        try {
+          const variantes = await api.get(`/getVariantesDesservantArret/${idArret}`)
+          if (variantes.data) {
+            const map = {}
+            for (const v of variantes.data) {
+              if (!map[v.idLigne]) map[v.idLigne] = {}
+              if (!map[v.idLigne][v.sensAller]) map[v.idLigne][v.sensAller] = {}
+              map[v.idLigne][v.sensAller][v.destination] = v.idVariante
+            }
+            variantesMap.value = map
+          }
+        } catch (err) {
+          console.error(err)
+        }
+      }
     }
   } catch (error) {
     console.error(error)
@@ -35,22 +55,28 @@ const lignesRegroupees = computed(() => {
         numLignePublic: t.numLignePublic,
         couleurFond: t.couleurFond,
         couleurTexte: t.couleurTexte,
+        idLigne: t.idLigne,
         destinations: {},
       }
     }
     // Deuxième niveau : destination
     if (!lignesMap[t.numLignePublic].destinations[t.destination]) {
-      lignesMap[t.numLignePublic].destinations[t.destination] = []
+      lignesMap[t.numLignePublic].destinations[t.destination] = {
+        horaires: [],
+        sensAller: t.sensAller,
+      }
     }
-    lignesMap[t.numLignePublic].destinations[t.destination].push(t)
+    lignesMap[t.numLignePublic].destinations[t.destination].horaires.push(t)
   }
 
   // On convertit les destinations en tableaux pour itérer plus facilement
   return Object.values(lignesMap).map((ligne) => ({
     ...ligne,
-    destinations: Object.entries(ligne.destinations).map(([destination, horaires]) => ({
+    destinations: Object.entries(ligne.destinations).map(([destination, data]) => ({
       destination,
-      horaires,
+      horaires: data.horaires,
+      idVariante:
+        variantesMap.value?.[ligne.idLigne]?.[data.sensAller]?.[destination],
     })),
   }))
 })
@@ -71,16 +97,25 @@ const lignesRegroupees = computed(() => {
       <div v-if="lignes && lignes.listeTemps && lignes.listeTemps.length" class="space-y-6">
         <div v-for="ligne in lignesRegroupees" :key="ligne.numLignePublic"
           class="bg-white dark:bg-dark-secondary p-4 rounded-lg shadow-md">
-          <h2 class="font-bold text-lg mb-3 flex items-center gap-3">
-            <span class="inline-block px-3 py-1 rounded-full font-bold text-sm"
-              :style="{ backgroundColor: '#' + ligne.couleurFond, color: '#' + ligne.couleurTexte }">
-              {{ ligne.numLignePublic }}
-            </span>
-          </h2>
           <div v-for="dest in ligne.destinations" :key="dest.destination" class="mb-3">
-            <h3 class="font-bold text-base mb-1 text-light-text dark:text-dark-text">
-              {{ dest.destination }}
-            </h3>
+            <h2 class="font-bold text-lg mb-3 flex items-center gap-3">
+              <router-link :to="{
+                name: 'ArretFromLigneView',
+                params: {
+                  idLigne: ligne.idLigne,
+                  idVariante: dest.idVariante,
+                  numLigne: ligne.numLignePublic,
+                },
+              }">
+                <span class="inline-block px-3 py-1 rounded-full font-bold text-sm"
+                  :style="{ backgroundColor: '#' + ligne.couleurFond, color: '#' + ligne.couleurTexte }">
+                  {{ ligne.numLignePublic }}
+                </span>
+              </router-link>
+              <span class="font-bold text-base text-light-text dark:text-dark-text">
+                {{ dest.destination }}
+              </span>
+            </h2>
             <ul class="flex justify-between px-10">
               <li v-for="(horaire, index) in dest.horaires" :key="index">
                 <router-link v-if="horaire.numVehicule" :to="{


### PR DESCRIPTION
## Summary
- fetch variant data for a stop and build line/destination lookup
- include idVariante in grouped line data
- link line badges to ArretFromLigneView with line and variant details

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a785cb203c8322a9c407ef8e28dec5