### PR TITLE
Handle missing variant id in stop view

### DIFF
--- a/front/src/views/arret.vue
+++ b/front/src/views/arret.vue
@@ -104,6 +104,7 @@ const lignesRegroupees = computed(() => {
           <div v-for="dest in ligne.destinations" :key="dest.destination" class="mb-3">
             <h2 class="font-bold text-lg mb-3 flex items-center gap-3">
               <router-link
+                v-if="dest.idVariante"
                 :to="{
                   name: 'ArretFromLigneView',
                   params: {
@@ -123,6 +124,16 @@ const lignesRegroupees = computed(() => {
                   {{ ligne.numLignePublic }}
                 </span>
               </router-link>
+              <span
+                v-else
+                class="inline-block px-3 py-1 rounded-full font-bold text-sm"
+                :style="{
+                  backgroundColor: '#' + ligne.couleurFond,
+                  color: '#' + ligne.couleurTexte,
+                }"
+              >
+                {{ ligne.numLignePublic }}
+              </span>
               <span class="font-bold text-base text-light-text dark:text-dark-text">
                 {{ dest.destination }}
               </span>


### PR DESCRIPTION
## Summary
- avoid router errors when variant id is missing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7879f0ad48322a158f954268b86b2