### PR TITLE
Avoid empty message loading and hide non-perturbed lines

### DIFF
--- a/front/src/components/perturbation.vue
+++ b/front/src/components/perturbation.vue
@@ -57,16 +57,19 @@ const toHexColor = (value, fallback = '#000000') => {
 const processedItems = computed(() => {
   if (!Array.isArray(raw.value)) return []
 
-  return raw.value.map((item, index) => ({
-    id: item.idLigne ?? item.id ?? index, // garde pour :key
-    idLigne: String(item.idLigne ?? item.id ?? index), // <- param de route
-    label: item.numLignePublic ?? '',
-    bg: toHexColor(item.couleurFond, '#222222'),
-    fg: toHexColor(item.couleurTexte, '#FFFFFF'),
-    etat: item.etat ?? null,
-    etatMessage: getEtatMessage(item.etat),
-    icon: ETAT_ICONS[item.etat] || null,
-  }))
+  // Ne conserver que les lignes réellement perturbées
+  return raw.value
+    .filter((item) => typeof item.etat === 'number' && item.etat > 1)
+    .map((item, index) => ({
+      id: item.idLigne ?? item.id ?? index, // garde pour :key
+      idLigne: String(item.idLigne ?? item.id ?? index), // <- param de route
+      label: item.numLignePublic ?? '',
+      bg: toHexColor(item.couleurFond, '#222222'),
+      fg: toHexColor(item.couleurTexte, '#FFFFFF'),
+      etat: item.etat ?? null,
+      etatMessage: getEtatMessage(item.etat),
+      icon: ETAT_ICONS[item.etat] || null,
+    }))
 })
 
 


### PR DESCRIPTION
## Summary
- filter fetched lines to only show those with real perturbations
- pre-process messages and add explicit loading/empty states to avoid spinners on normal lines

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68b064e0678c8322a645f52f4842d5c0