### PR TITLE
feat(front): reset scroll on route change

### DIFF
--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -8,6 +8,9 @@ import { createRouter, createWebHistory } from 'vue-router'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
+  scrollBehavior() {
+    return { left: 0, top: 0 }
+  },
   routes: [
     {
       path: '/',


### PR DESCRIPTION
## Summary
- reset scroll position on each route change via router scrollBehavior

## Testing
- `pnpm lint`
- `pnpm test` (fails: Missing script test)


------
https://chatgpt.com/codex/tasks/task_e_68b2d28e7060832298f920c5f3176487