### PR TITLE
Improve page focus handling for better accessibility

### DIFF
--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -4,7 +4,7 @@
   <div
     class="min-h-screen flex flex-col bg-light-bg text-light-text dark:bg-dark-bg dark:text-dark-text"
   >
-    <main class="flex-1 flex flex-col">
+    <main id="main-content" tabindex="-1" class="flex-1 flex flex-col">
       <router-view class="flex-1 flex flex-col" />
     </main>
 

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -5,6 +5,7 @@ import InfosTransport from '@/views/infos-transport.vue'
 import Lignes from '@/views/lignes.vue'
 import Message from '@/views/message.vue'
 import { createRouter, createWebHistory } from 'vue-router'
+import { nextTick } from 'vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -46,6 +47,20 @@ const router = createRouter({
       props: true,
     }
   ],
+})
+
+router.afterEach(() => {
+  nextTick(() => {
+    const main = document.getElementById('main-content')
+    if (!main) return
+    const h1 = main.querySelector('h1')
+    if (h1) {
+      h1.setAttribute('tabindex', '-1')
+      h1.focus()
+    } else {
+      main.focus()
+    }
+  })
 })
 
 export default router

--- a/front/src/views/home.vue
+++ b/front/src/views/home.vue
@@ -72,6 +72,7 @@ watch(searchTerm, () => {
   <div
     class="flex items-center justify-start flex-col min-h-full w-full py-8 bg-light-bg text-light-text dark:bg-dark-bg dark:text-dark-text"
   >
+    <h1 class="sr-only">Accueil</h1>
     <div ref="wrapperRef" class="relative w-80" role="search">
       <label for="searchInput" class="sr-only">Rechercher un arrêt</label>
       <div


### PR DESCRIPTION
## Summary
- Assign a focus target to the main content container
- Restore focus to the new page's heading after router navigation
- Provide a hidden `<h1>` on the home page for screen readers

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68b2d98f34d48322ab50a942cb2a6a31